### PR TITLE
The `Headers` object is now flattened before fetch

### DIFF
--- a/__tests__/authenticatedFetch/dpop/DpopAuthenticatedFetcher.spec.ts
+++ b/__tests__/authenticatedFetch/dpop/DpopAuthenticatedFetcher.spec.ts
@@ -151,8 +151,6 @@ describe("DpopAuthenticatedFetcher", () => {
       myHeaders.append("accept", "application/json");
       myHeaders.append("content-type", "text/turtle");
       const flatHeaders = flattenHeaders(myHeaders);
-      expect(flatHeaders["accept"]).toEqual("application/json");
-      expect(flatHeaders["content-type"]).toEqual("text/turtle");
       expect(Object.entries(flatHeaders)).toEqual([
         ["accept", "application/json"],
         ["content-type", "text/turtle"]

--- a/__tests__/authenticatedFetch/dpop/DpopAuthenticatedFetcher.spec.ts
+++ b/__tests__/authenticatedFetch/dpop/DpopAuthenticatedFetcher.spec.ts
@@ -24,6 +24,7 @@
  */
 import "reflect-metadata";
 import DpopAuthenticatedFetcher from "../../../src/authenticatedFetch/dpop/DpopAuthenticatedFetcher";
+import { flattenHeaders } from "../../../src/authenticatedFetch/dpop/DpopAuthenticatedFetcher";
 import URL from "url-parse";
 import {
   DpopHeaderCreatorMock,
@@ -127,7 +128,7 @@ describe("DpopAuthenticatedFetcher", () => {
       expect(response).toBe(FetcherMockResponse);
     });
 
-    it("Defaults to an unauthenticated request if the token isn't available", async () => {
+    it("defaults to an unauthenticated request if the token isn't available", async () => {
       defaultMocks.storageUtility.getForUser.mockResolvedValueOnce(null);
       const fetcher = FetcherMock;
       const dpopAuthenticatedFetcher = getDpopAuthenticatedFetcher({
@@ -141,6 +142,21 @@ describe("DpopAuthenticatedFetcher", () => {
       expect(fetcher.fetch).toHaveBeenCalledWith(url, {
         headers: {}
       });
+    });
+  });
+
+  describe("Headers interoperability function", () => {
+    it("transforms an incoming Headers object into a flat headers structure", () => {
+      const myHeaders = new Headers();
+      myHeaders.append("accept", "application/json");
+      myHeaders.append("content-type", "text/turtle");
+      const flatHeaders = flattenHeaders(myHeaders);
+      expect(flatHeaders["accept"]).toEqual("application/json");
+      expect(flatHeaders["content-type"]).toEqual("text/turtle");
+      expect(Object.entries(flatHeaders)).toEqual([
+        ["accept", "application/json"],
+        ["content-type", "text/turtle"]
+      ]);
     });
   });
 

--- a/src/authenticatedFetch/dpop/DpopAuthenticatedFetcher.ts
+++ b/src/authenticatedFetch/dpop/DpopAuthenticatedFetcher.ts
@@ -86,14 +86,14 @@ export default class DpopAuthenticatedFetcher implements IAuthenticatedFetcher {
       // perform unauthenticated fetch
       return this.fetcher.fetch(url, {
         ...requestInit,
-        headers: flattenHeaders(requestInitiWithDefaults?.headers)
+        headers: flattenHeaders(requestInitiWithDefaults.headers)
       });
     }
 
     return this.fetcher.fetch(url, {
       ...requestInit,
       headers: {
-        ...flattenHeaders(requestInitiWithDefaults?.headers),
+        ...flattenHeaders(requestInitiWithDefaults.headers),
         authorization: `DPOP ${authToken}`,
         dpop: await this.dpopHeaderCreator.createHeaderToken(
           this.urlRepresentationConverter.requestInfoToUrl(url),

--- a/src/authenticatedFetch/dpop/DpopAuthenticatedFetcher.ts
+++ b/src/authenticatedFetch/dpop/DpopAuthenticatedFetcher.ts
@@ -32,7 +32,7 @@ import { IDpopHeaderCreator } from "../../dpop/DpopHeaderCreator";
 import { IUrlRepresentationConverter } from "../../util/UrlRepresenationConverter";
 import { IStorageUtility } from "../../localStorage/StorageUtility";
 
-function flattenHeaders(
+export function flattenHeaders(
   headersToFlatten: Headers | string[][] | Record<string, string> | undefined
 ): Record<string, string> {
   const flatHeaders: Record<string, string> = {};

--- a/src/authenticatedFetch/dpop/DpopAuthenticatedFetcher.ts
+++ b/src/authenticatedFetch/dpop/DpopAuthenticatedFetcher.ts
@@ -32,6 +32,17 @@ import { IDpopHeaderCreator } from "../../dpop/DpopHeaderCreator";
 import { IUrlRepresentationConverter } from "../../util/UrlRepresenationConverter";
 import { IStorageUtility } from "../../localStorage/StorageUtility";
 
+function flattenHeaders(
+  headersToFlatten: Headers | string[][] | Record<string, string> | undefined
+): Record<string, string> {
+  const flatHeaders: Record<string, string> = {};
+  const iterableHeaders = new Headers(headersToFlatten);
+  iterableHeaders.forEach((value, key) => {
+    flatHeaders[key] = value;
+  });
+  return flatHeaders;
+}
+
 @injectable()
 export default class DpopAuthenticatedFetcher implements IAuthenticatedFetcher {
   constructor(
@@ -75,16 +86,14 @@ export default class DpopAuthenticatedFetcher implements IAuthenticatedFetcher {
       // perform unauthenticated fetch
       return this.fetcher.fetch(url, {
         ...requestInit,
-        headers: {
-          ...requestInitiWithDefaults.headers
-        }
+        headers: flattenHeaders(requestInitiWithDefaults?.headers)
       });
     }
 
     return this.fetcher.fetch(url, {
       ...requestInit,
       headers: {
-        ...requestInitiWithDefaults.headers,
+        ...flattenHeaders(requestInitiWithDefaults?.headers),
         authorization: `DPOP ${authToken}`,
         dpop: await this.dpopHeaderCreator.createHeaderToken(
           this.urlRepresentationConverter.requestInfoToUrl(url),


### PR DESCRIPTION
Resolves #88

It seems that an object implementing correctly the `Headers` interface is not processed correctly by `node-fetch`, pulled in by `cross-fetch`. I'll develop a minimal example to verify that this diagnosis is correct, and if so create an appropriate issue in the relevant repo. 