### PR TITLE
Replaced Headers type by NodeHeaders class for instantiation

### DIFF
--- a/src/authenticatedFetch/dpop/DpopAuthenticatedFetcher.ts
+++ b/src/authenticatedFetch/dpop/DpopAuthenticatedFetcher.ts
@@ -31,12 +31,13 @@ import { IFetcher } from "../../util/Fetcher";
 import { IDpopHeaderCreator } from "../../dpop/DpopHeaderCreator";
 import { IUrlRepresentationConverter } from "../../util/UrlRepresenationConverter";
 import { IStorageUtility } from "../../localStorage/StorageUtility";
+import { Headers as NodeHeaders } from "cross-fetch";
 
 export function flattenHeaders(
   headersToFlatten: Headers | string[][] | Record<string, string> | undefined
 ): Record<string, string> {
   const flatHeaders: Record<string, string> = {};
-  const iterableHeaders = new Headers(headersToFlatten);
+  const iterableHeaders = new NodeHeaders(headersToFlatten);
   iterableHeaders.forEach((value, key) => {
     flatHeaders[key] = value;
   });


### PR DESCRIPTION
Following a conversation we had around this exact topic in an NSS PR, I realized that the code I just wrote to fix the Headers issue used `lib.dom.d.ts:Headers` as a class, which is incorrect. The weird thing is that this line is covered by unit tests that did not pick up the issue, neither did the downstream libraries using the code (e.g. `LDflex-Comunica`). It's only when writing a super-simple code snippet (see below) for test purpose that this blew up:
```javascript
const auth = require('@inrupt/solid-auth-fetcher')

auth.fetch("http://some.iri/")
.then(response => response.text())
.then(data => console.log(data));
```

