### PR TITLE
Fix webpack export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-auth-fetcher",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "license": "MIT",
   "main": "dist/index.js",
   "browser": "browserDist/solid-auth-fetcher.bundle.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@inrupt/solid-auth-fetcher",
   "version": "0.0.4",
   "license": "MIT",
-  "main": "dist/index",
+  "main": "dist/index.js",
   "browser": "browserDist/solid-auth-fetcher.bundle.js",
   "types": "dist/index",
   "files": [
@@ -21,7 +21,7 @@
     "clean-test-helper": "cd examples/test-helper && npm run clean",
     "build": "npm run build-module && npm run build-browser",
     "build-module": "npm run clean-module && tsc -p tsconfig.json",
-    "build-browser": "npm run clean-browser && webpack --config webpack.config.js --env.env=prod",
+    "build-browser": "npm run clean-browser && webpack --config webpack.browser.js --env.env=prod",
     "analyze-bundle": "npm run clean-browser && webpack --config webpack.config.js --env.env=analyze",
     "lint": "eslint src/**/*.ts && eslint __tests__/**/*.ts",
     "lint-fix": "eslint --config .eslintrc.json --fix \"src/**\" && eslint --config .eslintrc.json --fix \"__tests__/**/*.ts\"",

--- a/webpack.browser.js
+++ b/webpack.browser.js
@@ -1,0 +1,16 @@
+const webpackMerge = require("webpack-merge");
+
+const commonConfig = require("./webpack.common.js");
+
+module.exports = ({ env, addon }) => {
+  const envConfig = require(`./webpack.${env}.js`);
+
+  const browserConfig = {
+    output: {
+      libraryTarget: "var",
+      library: "solidAuthFetcher"
+    }
+  };
+
+  return webpackMerge(commonConfig, envConfig, browserConfig);
+};

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -24,7 +24,6 @@ module.exports = {
   output: {
     filename: "solid-auth-fetcher.bundle.js",
     path: path.resolve(__dirname, "browserDist"),
-    libraryTarget: "var",
-    library: "solidAuthFetcher"
+    libraryTarget: "commonjs"
   }
 };


### PR DESCRIPTION
Updates the libraryTarget to export a commonjs module, which plays nicely with nodejs. However, this will _not_ export a global variable like it currently does - which means you can't just drop the compiled javascript on a page (like the first example on the README.) Two questions:

* Is exporting a global variable useful, or can we assume any user of SAF is using a bundler like webpack?
* If so, we can create a "dist/browser.js" file that imports "dist/index.js" and sets `global.solidAuthFetcher`.