### PR TITLE
Disabled Whitesource CI status check

### DIFF
--- a/.github/workflows/whitesource.yml
+++ b/.github/workflows/whitesource.yml
@@ -3,7 +3,8 @@ name: Whitesource Security Scan
 on:
   # The config is set up to verify compliance on pull requests, and to update the
   # whitesource inventory on push to the master branch.
-  pull_request:
+  # NOTE: Due to a bug in Whitesource, it is currently disabled for PRs.
+  # pull_request:
   push:
     branches:
       - master


### PR DESCRIPTION
There is a bug in Whitesource that makes it impractical for CI status checks. However, this change still runs a Whitesource scan on push to master, so that our dashboard stays in sync with the state of the repository. It won't affect the CI pipeline, and might introduce false positives that we can manually dismiss, but it still provides some feedback on security issues.