### PR TITLE
Remove browser from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,8 @@
 {
   "name": "@inrupt/solid-auth-fetcher",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "license": "MIT",
   "main": "dist/index.js",
-  "browser": "browserDist/solid-auth-fetcher.bundle.js",
   "types": "dist/index",
   "files": [
     "dist",


### PR DESCRIPTION
The browser field hints to bundlers like webpack to use that file for
browser packages; as this is the npm package, it's unnecessary and
causes bundled code to act differently from node.js code.

Users who want to use the browser bundle can still build the project and
drop browserDist into their projects.