### PR TITLE
Exclude dependabot branches from the preview-app releases

### DIFF
--- a/.github/workflows/cd-preview.yml
+++ b/.github/workflows/cd-preview.yml
@@ -1,6 +1,10 @@
 name: CD-preview
 
-on: [push]
+on: 
+  push:
+    branches-ignore:
+      - dependabot/*
+
 
 env:
   CI: true


### PR DESCRIPTION
This PR fixes a undesired behaviour by creating a large number of preview releases due to dependabot PRs.

- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).