### PR TITLE
Defaults to a browser fetch instead of `cross-fetch`

### DIFF
--- a/__tests__/util/Fetcher.spec.ts
+++ b/__tests__/util/Fetcher.spec.ts
@@ -43,3 +43,19 @@ describe("UuidGenerator", () => {
     );
   });
 });
+
+describe("Browser behaviour", () => {
+  it("should default to the environment's fetch if available", async () => {
+    const mockCrossFetch = jest.requireMock("cross-fetch");
+    mockCrossFetch.mockReturnValueOnce(Promise.resolve("cross-fetch response"));
+    window.fetch = jest
+      .fn()
+      .mockReturnValueOnce(Promise.resolve("browser fetch response"));
+
+    const fetcher = new Fetcher();
+    expect(await fetcher.fetch("https://someurl.com")).toBe(
+      "browser fetch response"
+    );
+    expect(mockCrossFetch.mock.calls.length).toEqual(0);
+  });
+});

--- a/src/util/Fetcher.ts
+++ b/src/util/Fetcher.ts
@@ -32,6 +32,9 @@ export interface IFetcher {
 export default class Fetcher implements IFetcher {
   async fetch(url: RequestInfo | URL, init?: RequestInit): Promise<Response> {
     const fetchUrl = url instanceof URL ? url.toString() : url;
+    if (typeof window !== undefined && typeof window.fetch !== undefined) {
+      return window.fetch(fetchUrl, init);
+    }
     return _fetch(fetchUrl, init);
   }
 }

--- a/src/util/Fetcher.ts
+++ b/src/util/Fetcher.ts
@@ -32,7 +32,7 @@ export interface IFetcher {
 export default class Fetcher implements IFetcher {
   async fetch(url: RequestInfo | URL, init?: RequestInit): Promise<Response> {
     const fetchUrl = url instanceof URL ? url.toString() : url;
-    if (typeof window !== undefined && typeof window.fetch !== undefined) {
+    if (typeof window !== "undefined" && typeof window.fetch !== "undefined") {
       return window.fetch(fetchUrl, init);
     }
     return _fetch(fetchUrl, init);


### PR DESCRIPTION
If a browser fetch implementation is available, then it is used instead of `cross-fetch`. This is because cross-fetch uses a polyfill for fetch, which is incomplete and lacks some standard behaviour that is required in some of our use cases, such as reading responses as streams for LDflex.

This PR contributes to fixing bug #173. However, the problem persists in a `Node` environment.

- [x] I've added a unit test to test for potential regressions of this bug.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).