### PR TITLE
Clean the LDflex workaround up

### DIFF
--- a/__tests__/authenticatedFetch/headers/HeadersUtils.spec.ts
+++ b/__tests__/authenticatedFetch/headers/HeadersUtils.spec.ts
@@ -39,24 +39,4 @@ describe("Headers interoperability function", () => {
       ["content-type", "text/turtle"]
     ]);
   });
-
-  it("supports Comunica-style headers structures", () => {
-    // This enables testing that an object similar to the prototypes passed by
-    // Comunica is supported.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const myHeaders: any = {};
-    myHeaders["accept"] = "application/json";
-    myHeaders["content-type"] = "text/turtle";
-    myHeaders["raw"] = (): Record<string, string> => {
-      return {
-        accept: "application/json",
-        "content-type": "text/turtle"
-      };
-    };
-    const flatHeaders = flattenHeaders(myHeaders);
-    expect(Object.entries(flatHeaders)).toEqual([
-      ["accept", "application/json"],
-      ["content-type", "text/turtle"]
-    ]);
-  });
 });

--- a/__tests__/authenticatedFetch/headers/HeadersUtils.spec.ts
+++ b/__tests__/authenticatedFetch/headers/HeadersUtils.spec.ts
@@ -39,4 +39,20 @@ describe("Headers interoperability function", () => {
       ["content-type", "text/turtle"]
     ]);
   });
+
+  it("supports non-iterable headers if they provide a reasonably standard way of browsing them", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const myHeaders: any = {};
+    myHeaders["forEach"] = (
+      callback: (value: string, key: string) => void
+    ): void => {
+      callback("application/json", "accept");
+      callback("text/turtle", "content-type");
+    };
+    const flatHeaders = flattenHeaders(myHeaders);
+    expect(Object.entries(flatHeaders)).toEqual([
+      ["accept", "application/json"],
+      ["content-type", "text/turtle"]
+    ]);
+  });
 });

--- a/src/authenticatedFetch/dpop/DpopAuthenticatedFetcher.ts
+++ b/src/authenticatedFetch/dpop/DpopAuthenticatedFetcher.ts
@@ -84,7 +84,7 @@ export default class DpopAuthenticatedFetcher implements IAuthenticatedFetcher {
     return this.fetcher.fetch(url, {
       ...requestInit,
       headers: {
-        ...flattenHeaders(requestInitiWithDefaults.headers),
+        ...flattenHeaders(requestInitiWithDefaults.headers as Headers),
         authorization: `DPOP ${authToken}`,
         dpop: await this.dpopHeaderCreator.createHeaderToken(
           this.urlRepresentationConverter.requestInfoToUrl(url),

--- a/src/authenticatedFetch/headers/HeadersUtils.ts
+++ b/src/authenticatedFetch/headers/HeadersUtils.ts
@@ -37,7 +37,7 @@ export function flattenHeaders(
 
   // If the headers are already a Record<string, string>,
   // they can directly be returned.
-  if (typeof headersToFlatten.forEach === "undefined") {
+  if (typeof headersToFlatten.forEach !== "function") {
     // @ts-ignore
     return headersToFlatten;
   }

--- a/src/authenticatedFetch/headers/HeadersUtils.ts
+++ b/src/authenticatedFetch/headers/HeadersUtils.ts
@@ -21,45 +21,6 @@
 
 /**
  * @internal
- * This method is a temporary fix: as per the MDN spec (https://developer.mozilla.org/en-US/docs/Web/API/Headers),
- * the Headers object should have a `.keys()` method. It turns out that some implementations
- * do not implement this method, so this check is necessary to verify how to access
- * the header's content.
- * @param headers A header potentially of the type provided by LDflex-Comunica
- */
-function hasKeys(
-  headers: Headers | string[][] | Record<string, string> | undefined | unknown
-): headers is Headers | string[][] {
-  return (
-    // eslint-disable-next-line
-    // @ts-ignore
-    headers !== undefined && headers.keys !== undefined
-  );
-}
-
-/**
- * @internal
- * This method is a temporary fix: we receive from LDflex-Comunica an object
- * that is not conform to the Headers interface. This mitigates the issue
- * until a cleaner fix is found. This method may be seen as a type guard for
- * a LDflex-Comunica header.
- * @param headers A header potentially of the type provided by LDflex-Comunica
- */
-function hasRawGetter(
-  // The 'any' type here is needed because no type definition covers properly
-  // the headers object we want to check against here.
-  // eslint-disable-next-line
-  headers: any
-): boolean {
-  return (
-    // eslint-disable-next-line
-    // @ts-ignore
-    headers !== undefined && headers.raw !== undefined
-  );
-}
-
-/**
- * @internal
  * This function feels unnecessarily complicated, but is required in order to
  * have Headers according to type definitions in both Node and browser environments.
  * This might require a fix upstream to be cleaned up.
@@ -67,34 +28,23 @@ function hasRawGetter(
  * @param headersToFlatten A structure containing headers potentially in several formats
  */
 export function flattenHeaders(
-  headersToFlatten: Headers | string[][] | Record<string, string> | undefined
+  headersToFlatten: Headers | Record<string, string> | string[][] | undefined
 ): Record<string, string> {
-  if (headersToFlatten === undefined) {
+  if (typeof headersToFlatten === "undefined") {
     return {};
   }
   const flatHeaders: Record<string, string> = {};
-  if (!hasKeys(headersToFlatten)) {
-    if (hasRawGetter(headersToFlatten)) {
-      // This is needed because the headers object passed by Comunica do not
-      // align with either `node-fetch::Headers` or `lib.dom.d.ts::Headers`,
-      // and gets mangled if passed as is to cross-fetch.
-      // eslint-disable-next-line
-      // @ts-ignore
-      return headersToFlatten.raw();
-    } else {
-      return headersToFlatten as Record<string, string>;
-    }
-  } else {
-    // headersToFlatten.keys() SHOULD be valid as per the Headers spec. This seems to be an issue
-    // in lib.dom.d.ts that will need some investigation and potentially a contrib upstream.
-    // eslint-disable-next-line
+
+  // If the headers are already a Record<string, string>,
+  // they can directly be returned.
+  if (typeof headersToFlatten.forEach === "undefined") {
     // @ts-ignore
-    for (const key of headersToFlatten.keys()) {
-      // Similar as the previous @ts-ignore
-      // eslint-disable-next-line
-      // @ts-ignore
-      flatHeaders[key] = headersToFlatten.get(key);
-    }
+    return headersToFlatten;
   }
+
+  // @ts-ignore
+  headersToFlatten.forEach((value: string, key: string) => {
+    flatHeaders[key] = value;
+  });
   return flatHeaders;
 }

--- a/src/authenticatedFetch/unauthenticated/UnauthenticatedFetcher.ts
+++ b/src/authenticatedFetch/unauthenticated/UnauthenticatedFetcher.ts
@@ -30,6 +30,7 @@ import { IDpopHeaderCreator } from "../../dpop/DpopHeaderCreator";
 import { IUrlRepresentationConverter } from "../../util/UrlRepresenationConverter";
 import { IStorageUtility } from "../../localStorage/StorageUtility";
 import { flattenHeaders } from "../headers/HeadersUtils";
+import { Headers as NodeHeaders } from "node-fetch";
 
 @injectable()
 export default class DpopAuthenticatedFetcher implements IAuthenticatedFetcher {
@@ -67,6 +68,9 @@ export default class DpopAuthenticatedFetcher implements IAuthenticatedFetcher {
     url: RequestInfo,
     requestInit?: RequestInit
   ): Promise<Response> {
+    if (requestInit?.headers) {
+      console.log("Received headers");
+    }
     return this.fetcher.fetch(url, {
       ...requestInit,
       method: requestInit?.method ?? "GET",

--- a/src/authenticatedFetch/unauthenticated/UnauthenticatedFetcher.ts
+++ b/src/authenticatedFetch/unauthenticated/UnauthenticatedFetcher.ts
@@ -30,7 +30,6 @@ import { IDpopHeaderCreator } from "../../dpop/DpopHeaderCreator";
 import { IUrlRepresentationConverter } from "../../util/UrlRepresenationConverter";
 import { IStorageUtility } from "../../localStorage/StorageUtility";
 import { flattenHeaders } from "../headers/HeadersUtils";
-import { Headers as NodeHeaders } from "node-fetch";
 
 @injectable()
 export default class DpopAuthenticatedFetcher implements IAuthenticatedFetcher {
@@ -68,9 +67,6 @@ export default class DpopAuthenticatedFetcher implements IAuthenticatedFetcher {
     url: RequestInfo,
     requestInit?: RequestInit
   ): Promise<Response> {
-    if (requestInit?.headers) {
-      console.log("Received headers");
-    }
     return this.fetcher.fetch(url, {
       ...requestInit,
       method: requestInit?.method ?? "GET",


### PR DESCRIPTION
The previous workaround was unnecessarily convoluted, and a simpler, more standard approach is supported. However, there is still a conflict between the `lib.dom.d.ts` Headers type and the reference https://fetch.spec.whatwg.org/#headers-class. An issue will be opened to track this.

This PR contributes to fixing bug #176.

- [x] I've added a unit test to test for potential regressions of this bug. (actually I removed the LDflex-Comunica-specific test)
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).